### PR TITLE
Removes Microsoft.NET.Sdk.Web reference

### DIFF
--- a/aspnetapp.csproj
+++ b/aspnetapp.csproj
@@ -5,8 +5,4 @@
     <UserSecretsId>31051026529000467138</UserSecretsId>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Per build: warning NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically.