### PR TITLE
Fix variable name typo (DOTNETCORE_VESRION -> DOTNETCORE_VERSION)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DOTNETCORE_VESRION=3.0
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
+ARG DOTNETCORE_VERSION=3.0
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VERSION}
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs


### PR DESCRIPTION
This is due to the original example being wrong, for which I have opened a PR as well: https://github.com/microsoft/vscode-dev-containers/pull/179