### PR TITLE
Base Dev-Container on Ubuntu Bionic image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-bionic
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs


### PR DESCRIPTION
The docker image `mcr.microsoft.com/dotnet/core/sdk:3.1` is a multiarch image supporting multiple operating systems and architectures. In order to ensure that a Ubuntu system image is used, the dev container should base on the .NET Core image for Ubuntu Bionic.

This Docker causes issues on Docker on Windows, as `mcr.microsoft.com/dotnet/core/sdk:3.1` resolves to the .NET Core image based on Windows Server Core. Subsequently the build command will fail, as there is no `apt` on Windows.