### PR TITLE
Add customizations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,13 +12,19 @@
 		}
 	},
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": { },
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-dotnettools.csharp"
-	],
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-dotnettools.csharp"
+			]
+		}
+	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5001],


### PR DESCRIPTION
I left the blank `settings` property as I thought these might have a slightly different use case than the vscode-dev-containers definitions and it'd be helpful to include it as a reference, but happy to discuss further.