### PR TITLE
update devcontainer to .net 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "C# (.NET)",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:0-7.0",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net7.0/vscode-remote-try-dotnet.dll",
+            "program": "${workspaceFolder}/bin/Debug/net8.0/vscode-remote-try-dotnet.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/vscode-remote-try-dotnet.csproj
+++ b/vscode-remote-try-dotnet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>vscode_remote_try_dotnet</RootNamespace>


### PR DESCRIPTION
updates to .NET 8 based on the updated devcontainer/dotnet. As there is no tag 0-8.0, I switched to 1-8.0.